### PR TITLE
Add Particl to atomic swap compatible list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Created by: www.altcoinexchange.com
 
-This is Ethereum version of atomic swap compatible for use with existing Bitcoin, Litecoin and Vertcoin in this repo: https://github.com/decred/atomicswap
+This is Ethereum version of atomic swap compatible for use with existing Bitcoin, Litecoin, Vertcoin and Particl in this repo: https://github.com/decred/atomicswap
 
 Do not use this on mainnet since it's not yet properly audited and still in testing. Documentation and web3 client command line tool coming soon. Contributions and issues are welcome.
 


### PR DESCRIPTION
Particl was added by Decred in https://github.com/decred/atomicswap on Oct. 24.
Reference: https://github.com/decred/atomicswap/commit/2bdb0d870c6c82fc0b92f69aef3b00b074fbaacb